### PR TITLE
updates Python metadata to match LICENSE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     version='0.0.3',
     author='Manan Lalit',
     author_email='lalit@mpi-cbg.de',
-    license='BSD-3',
+    license='CC-BY-NC-4.0',
     url='https://github.com/juglab/PlatyMatch',
     description='PlatyMatch allows registration of volumetric images of embryos by establishing correspondences between cells',
     long_description=read('README.md'),


### PR DESCRIPTION
Hello! I was looking at the listing of PlatyMatch on the [napari hub](https://www.napari-hub.org/plugins/PlatyMatch) and wanted to help make sure that the napari hub accurately displays your license information.

- in your setup.py file, you have designated `BSD-3` as the license (I assume this was inherited from the CookieCutter?)
- however, your LICENSE file contains a Creative Commons Attribution Non Commercial 4.0 International license

This PR assumes that the LICENSE file is the intended, correct license, and updates the metadata in setup.py accordingly with the SPDX Short Identifier for this license.