### PR TITLE
Fix: Make sure to not depend on PyQt

### DIFF
--- a/platymatch/_dock_widget.py
+++ b/platymatch/_dock_widget.py
@@ -2,9 +2,9 @@ import SimpleITK as sitk
 import csv
 import numpy as np
 import tifffile
-from PyQt5.QtCore import Qt
 from napari.qt.threading import thread_worker
 from napari_plugin_engine import napari_hook_implementation
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QWidget, QGridLayout, QVBoxLayout, QPushButton, QCheckBox, QLabel, QComboBox, QLineEdit, \
     QFileDialog, QProgressBar
 from scipy.optimize import linear_sum_assignment

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ scikit-image
 scikit-learn
 tqdm
 simpleitk
-napari[all]
+napari
 pandas
 pytest
+qtpy


### PR DESCRIPTION
Hi, your `requirements.txt` has `napari[all]`, which ends up bringing PyQt5:
See:
https://github.com/napari/napari/blob/3bf872cbb1df98665fdb7d5e0f3e1a4845a84202/setup.cfg#L97-L106
This is problematic when using conda installed napari, which will have Qt from conda that has a different name (`pyqt`), breaking the environment. This can happen if the user uses the plugin GUI to install.
Another example is on arm64 macOS where pip doesn't have a wheel for PyQt5, so conda-forge is the only option, because building the binary from source is problematic.
The napari guide for plugins suggests avoiding this:
https://napari.org/stable/plugins/best_practices.html#don-t-include-pyside2-or-pyqt5-in-your-plugin-s-dependencies
Likewise, there is an import from PyQt, which is likewise problematic.

So in this PR I've replaced the import from PyQt with the equivalent import from `qtpy` which can use whatever Qt is available and then changed the requirement from `napari[all]` to `napari` with the addition of `qtpy`.

Now on my arm64 macOS this package installs with no issues.